### PR TITLE
Add optional parameters to retrieval tool: topK, rerank, and recencyBias

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,9 @@ The Ragie retrieval tool will now be available in your Claude desktop conversati
 The server provides a `retrieve` tool that can be used to search the knowledge base. It accepts the following parameters:
 
 - `query` (string): The search query to find relevant information
+- `topK` (number, optional, default: 8): The maximum number of results to return
+- `rerank` (boolean, optional, default: true): Whether to try and find only the most relevant information
+- `recencyBias` (boolean, optional, default: false): Whether to favor results towards more recent information
 
 The tool returns:
 - An array of content chunks containing matching text from the knowledge base

--- a/src/index.ts
+++ b/src/index.ts
@@ -59,11 +59,33 @@ server.tool(
     query: z
       .string()
       .describe("The query to search for data in the Knowledge Base"),
+    topK: z
+      .number()
+      .describe("The maximum number of results to return. Defaults to 8.")
+      .optional()
+      .default(8),
+    rerank: z
+      .boolean()
+      .describe(
+        "Whether to try and find only the most relevant data. Defaults to true. If no relevant data is found, try again with this parameter set to false."
+      )
+      .optional()
+      .default(true),
+    recencyBias: z
+      .boolean()
+      .describe(
+        "Whether to favor data towards more recent documents. Defaults to false."
+      )
+      .optional()
+      .default(false),
   },
-  async ({ query }) => {
+  async ({ query, topK, rerank, recencyBias }) => {
     const ragie = new Ragie({ auth: RAGIE_API_KEY });
     const retrieval = await ragie.retrievals.retrieve({
       query,
+      topK,
+      rerank,
+      recencyBias,
       partition: options.partition,
     });
 


### PR DESCRIPTION
This pull request introduces new optional parameters to the `retrieve` tool and updates the server code to handle these parameters.

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R142-R144): Added descriptions for new optional parameters `topK`, `rerank`, and `recencyBias` to the `retrieve` tool documentation.

Server code updates:

* [`src/index.ts`](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80R62-R88): Added optional parameters `topK`, `rerank`, and `recencyBias` to the server tool configuration and updated the retrieval function to use these parameters.